### PR TITLE
Use mach_absolute_time() on __MACH__ systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ file(GLOB MY_SOURCES src/*.c)
 add_executable(test_bin ${MY_SOURCES})
 set_target_properties(test_bin PROPERTIES OUTPUT_NAME travis-test)
 target_link_libraries(test_bin ${MY_LIBS})
-
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_bin rt)
+endif()
 
 # turn on testing
 enable_testing()

--- a/src/timer.h
+++ b/src/timer.h
@@ -4,10 +4,14 @@
 /******************************************************************************
  * INCLUDES
  *****************************************************************************/
-#include <sys/time.h>
+#include <time.h>
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifdef __MACH__
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
 
 /******************************************************************************
  * STRUCTURES
@@ -20,8 +24,8 @@ typedef struct
 {
   bool running;
   double seconds;
-  struct timeval start;
-  struct timeval stop;
+  double start;
+  double stop;
 } sp_timer_t;
 
 
@@ -39,14 +43,28 @@ typedef struct
 */
 static inline void timer_reset(sp_timer_t * const timer)
 {
-  timer->running       = false;
-  timer->seconds       = 0;
-  timer->start.tv_sec  = 0;
-  timer->start.tv_usec = 0;
-  timer->stop.tv_sec   = 0;
-  timer->stop.tv_usec  = 0;
+  timer->running = false;
+  timer->seconds = 0;
+  timer->start   = 0;
+  timer->stop    = 0;
 }
 
+double monotonic_seconds()
+{
+#ifdef __MACH__
+  static mach_timebase_info_data_t info;
+  static double seconds_per_unit;
+  if(seconds_per_unit == 0) {
+    mach_timebase_info(&info);
+    seconds_per_unit = (info.numer / info.denom) / 1e9;
+  }
+  return seconds_per_unit * mach_absolute_time();
+#else
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec + ts.tv_nsec * 1e-9;
+#endif
+}
 
 /**
 * @brief Start a sp_timer_t. NOTE: this does not reset the timer.
@@ -57,7 +75,7 @@ static inline void timer_start(sp_timer_t * const timer)
 {
   if(!timer->running) {
     timer->running = true;
-    gettimeofday(&(timer->start), NULL);
+    timer->start = monotonic_seconds();
   }
 }
 
@@ -70,9 +88,8 @@ static inline void timer_start(sp_timer_t * const timer)
 static inline void timer_stop(sp_timer_t * const timer)
 {
   timer->running = false;
-  gettimeofday(&(timer->stop), NULL);
-  timer->seconds += (double)(timer->stop.tv_sec - timer->start.tv_sec);
-  timer->seconds += 1e-6 * (timer->stop.tv_usec - timer->start.tv_usec);
+  timer->stop = monotonic_seconds();
+  timer->seconds += timer->stop - timer->start;
 }
 
 


### PR DESCRIPTION
Hey Shady. Initially, I was storing `start` and `stop` using `timespec` which is a pair of seconds and nanoseconds ([see this solution](http://stackoverflow.com/a/5167506/5165894)). That worked, but the computation was a bit fiddly, so now I'm just getting a nanosecond resolution value and storing it as seconds. If the conversion is too lossy, we can go back to storing seconds and nanoseconds. Let me know if the Linux version works.
